### PR TITLE
Resolve fixture values at runtime by inspecting metatype information 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ func sum(_ numbers: Int...) -> Int {
 let fixture = Fixture()
 
 func testSum() throws {
-    let number1 = try fixture(Int.self)
-    let number2 = try fixture(Int.self)
+    let number1: Int = try fixture()
+    let number2: Int = try fixture()
 
     let expected = number1 + number2
     let actual = sum(number1, number2)
@@ -50,7 +50,7 @@ fixture.register(User.self) { fixture in
     )
 }
 
-let user = try fixture(User.self)
+let user: User = try fixture()
 // ▿ User
 //   ▿ id: C83AEAF9-EF48-4EEB-9684-EACA9AF2D6FE
 //     - uuid: "C83AEAF9-EF48-4EEB-9684-EACA9AF2D6FE"

--- a/Sources/SwiftFixture/Documentation.docc/Testing With SwiftFixture.md
+++ b/Sources/SwiftFixture/Documentation.docc/Testing With SwiftFixture.md
@@ -60,7 +60,7 @@ class SummaryTests: XCTestCase {
     let fixture = Fixture()
 
     func testSummaryForActiveUser() throws {
-        var user = try fixture(User.self)
+        var user: User = try fixture()
         user.isActive = true
 
         let actual = getSummary(for: user)
@@ -80,7 +80,7 @@ The ``Fixture`` class has a primary callable interface used to obtain a fixture 
 ```swift
 let fixture = Fixture(preferredFormat: .random)
 
-let value = try fixture(Int.self) // Int.random(in:)
+let value: Int = try fixture() // Int.random(in:)
 ```
 
 ### Registering value providers
@@ -94,7 +94,7 @@ fixture.register(User.self) { fixture in
     User(id: try fixture(), name: try fixture(), createdAt: try fixture(), isActive: try fixture())
 }
 
-let value = try fixture(User.self) // User.init(id:name:createdAt:isActive:)
+let value: User = try fixture() // User.init(id:name:createdAt:isActive:)
 ```
 
 If a type hasn't been registered, the ``ResolutionError`` type will instead be thrown. This is the only error thrown by ``Fixture`` itself, but your own value providers can also throw other errors as well (i.e if they relied on a throwable initializer).

--- a/Sources/SwiftFixture/Fixture.swift
+++ b/Sources/SwiftFixture/Fixture.swift
@@ -5,7 +5,7 @@
 /// ```swift
 /// let fixture = Fixture()
 /// // ...
-/// try fixture(Int.self) // Int.random(in: 0 ... .max)
+/// try fixture() as Int // Int.random(in: 0 ... .max)
 /// ```
 ///
 /// Alternatively, you can create an instance that vends constant values each time:
@@ -13,7 +13,7 @@
 /// ```swift
 /// let fixture = Fixture(preferredFormat: .constant)
 /// // ...
-/// try fixture(Int.self) // 0
+/// try fixture() as Int // 0
 /// ```
 ///
 /// `Fixture` is a [Callable type](https://github.com/apple/swift-evolution/blob/main/proposals/0253-callable.md) so values are retrieved using function call syntax.
@@ -40,7 +40,7 @@
 ///     )
 /// }
 ///
-/// try fixture(User.self)
+/// try fixture() as User
 /// // ▿ User
 /// //   ▿ id: 27310087-1F15-4033-B97B-9E6873B48918
 /// //     - uuid: "27310087-1F15-4033-B97B-9E6873B48918"
@@ -114,11 +114,9 @@ extension Fixture {
 }
 
 // MARK: - Value Lookup
-// TODO: Use something like Sorcery (eventually Macros) to simplify this overloading mess
-// First define each base overload, then the Optional equivalent, then a callAsFunction version of both.
 extension Fixture {
     /// Internal function for providing a fixture value via the registered provider for the given type
-    private func providerValue<T>(for type: T.Type = T.self) throws -> T? {
+    private func providerValue<T>(for type: Any.Type) throws -> T? {
         if let provideValue = providers[String(reflecting: type)] {
             return try provideValue() as? T
         } else {
@@ -129,125 +127,37 @@ extension Fixture {
     // MARK: Base Overloads
 
     /// Resolves a fixture value for the given type or throws an error if it cannot be resolved.
-    func value<T>(for type: T.Type = T.self) throws -> T {
-        if let value = try providerValue(for: T.self) {
+    func value<T>(for type: T.Type) throws -> T {
+        // If T is an Optional type, expose the Wrapped type for value lookup
+        let optionalType = type as? OptionalProtocol.Type
+        let wrappedType = optionalType?.wrappedType ?? type
+
+        // First, check the provider store for a value of the matching wrapped type
+        if let value: T = try providerValue(for: wrappedType) {
             return value
         }
 
-        if let type = type as? FixtureProviding.Type {
+        // Secondly, fallback to using FixtureProviding for the wrapped type
+        if let type = wrappedType as? FixtureProviding.Type {
             return try type.provideFixture(using: self) as! T
         }
 
-        throw ResolutionError.noProviderRegisteredForType(T.self)
-    }
-
-    /// Resolves a fixture value for the given type or throws an error if it cannot be resolved.
-    func value<T: RawRepresentable>(for type: T.Type = T.self) throws -> T {
-        if let value = try providerValue(for: T.self) {
-            return value
-        }
-
-        if let rawValue = try providerValue(for: T.RawValue.self), let value = T(rawValue: rawValue) {
-            return value
-        }
-
-        throw ResolutionError.noProviderRegisteredForType(type)
-    }
-
-    /// Resolves a fixture value for the given type or throws an error if it cannot be resolved.
-    func value<T: CaseIterable>(for type: T.Type = T.self) throws -> T {
-        if let value = try providerValue(for: T.self) {
-            return value
-        }
-
-        if let value = T.allCases.randomElement() {
-            return value
-        }
-
-        throw ResolutionError.noProviderRegisteredForType(type)
-    }
-
-    /// Resolves a fixture value for the given type or throws an error if it cannot be resolved.
-    func value<T>(for type: [T].Type = [T].self, count: Int = 1) throws -> [T] {
-        try (0 ..< count).map { _ in try value(for: T.self) }
-    }
-
-    // TODO: Support other collection types (Set, Dictionary..)
-
-    // MARK: Optional Overloads
-
-    func value<T>(for type: Optional<T>.Type = Optional<T>.self) throws -> T? {
-        do {
-            return try value(for: T.self)
-        } catch is ResolutionError {
-            return nil
-        } catch {
-            throw error
-        }
-    }
-
-    func value<T: RawRepresentable>(for type: Optional<T>.Type = Optional<T>.self) throws -> T? {
-        do {
-            return try value(for: T.self)
-        } catch is ResolutionError {
-            return nil
-        } catch {
-            throw error
-        }
-    }
-
-    func value<T: CaseIterable>(for type: Optional<T>.Type = Optional<T>.self) throws -> T? {
-        do {
-            return try value(for: T.self)
-        } catch is ResolutionError {
-            return nil
-        } catch {
-            throw error
-        }
-    }
-
-    func value<T>(for type: Optional<[T]>.Type = Optional<[T]>.self, count: Int = 1) throws -> [T]? {
-        do {
-            return try value(for: [T].self)
-        } catch is ResolutionError {
-            return nil
-        } catch {
-            throw error
+        // Finally, return the Optional's nil value or throw a resolution error
+        if let nilValue = optionalType?.nilValue as? T {
+            return nilValue
+        } else {
+            throw ResolutionError.noProviderRegisteredForType(T.self)
         }
     }
 }
 
 // MARK: - Call As Function
 public extension Fixture {
-    func callAsFunction<T>(_ type: T.Type = T.self) throws -> T {
-        try value(for: type)
+    func callAsFunction<T>() throws -> T {
+        try value(for: T.self)
     }
 
-    func callAsFunction<T: RawRepresentable>(_ type: T.Type = T.self) throws -> T {
-        try value(for: type)
-    }
-
-    func callAsFunction<T: CaseIterable>(_ type: T.Type = T.self) throws -> T {
-        try value(for: type)
-    }
-
-    func callAsFunction<T>(_ type: Optional<T>.Type = Optional<T>.self) throws -> T? {
-        try value(for: type)
-    }
-
-    func callAsFunction<T>(_ type: [T].Type = [T].self, count: Int = 1) throws -> [T] {
-        try value(for: type, count: count)
-    }
-
-    func callAsFunction<T: RawRepresentable>(_ type: Optional<T>.Type = Optional<T>.self) throws -> T? {
-        try value(for: type)
-    }
-
-    func callAsFunction<T: CaseIterable>(_ type: Optional<T>.Type = Optional<T>.self) throws -> T? {
-        try value(for: type)
-    }
-
-    func callAsFunction<T>(_ type: Optional<[T]>.Type = Optional<[T]>.self, count: Int = 1) throws -> [T]? {
-        try value(for: type, count: count)
+    func callAsFunction<T>(count: Int = 1) throws -> [T] {
+        try (0 ..< count).map { _ in try value(for: T.self) }
     }
 }

--- a/Sources/SwiftFixture/OptionalProtocol.swift
+++ b/Sources/SwiftFixture/OptionalProtocol.swift
@@ -1,0 +1,18 @@
+/// Internal protocol used to provide type information about `Optional` types at runtime.
+protocol OptionalProtocol {
+    /// `Optional<Wrapped>.none`
+    static var nilValue: Self { get }
+
+    /// Value of `Optional.Wrapped`
+    static var wrappedType: Any.Type { get }
+}
+
+extension Optional: OptionalProtocol {
+    static var nilValue: Optional<Wrapped> {
+        return .none
+    }
+
+    static var wrappedType: Any.Type {
+        Wrapped.self
+    }
+}


### PR DESCRIPTION
Prior to this change, I had many `callAsFunction(...)` overloads for different generic types such as `T`, `Optional<T>`, `FixtureProviding` etc etc however this had limitations.

For example, if `T` was declared `FixtureProviding` in one module, that information could end up getting lost at compile time resulting in the wrong overload being called. And when it comes to `Optional` types, having to overload every existing overload become quite messy.

Instead, it seemed to be more appropriate to 1) simplify things and 2) handle optional and `FixtureProviding` resolution dynamically at runtime instead. 

At the same time, it was also much simpler to adjust the syntax so that the `callAsFunction` method does not take a parameter describing `T`. I have adjusted the documentation to reflect this.

This also plays a part for the upcoming #6 enhancement.