### PR TITLE
Support Array, Set and Dictionary

### DIFF
--- a/Sources/SwiftFixture/FixtureProviding.swift
+++ b/Sources/SwiftFixture/FixtureProviding.swift
@@ -27,3 +27,34 @@ public protocol FixtureProviding {
     /// - Returns: An instance of `Self` initialized with values suitable for use in testing.
     static func provideFixture(using values: ValueProvider) throws -> Self
 }
+
+// MARK: - Containers
+extension Array: FixtureProviding {
+    public static func provideFixture(using values: ValueProvider) throws -> Array<Element> {
+        if let value: Element = try? values.get() {
+            return [value]
+        } else {
+            return Array()
+        }
+    }
+}
+
+extension Set: FixtureProviding {
+    public static func provideFixture(using values: ValueProvider) throws -> Set<Element> {
+        if let value: Element = try? values.get() {
+            return [value]
+        } else {
+            return Set()
+        }
+    }
+}
+
+extension Dictionary: FixtureProviding {
+    public static func provideFixture(using values: ValueProvider) throws -> Dictionary<Key, Value> {
+        if let key: Key = try? values.get(), let value: Value = try? values.get() {
+            return [key: value]
+        } else {
+            return Dictionary()
+        }
+    }
+}

--- a/Tests/SwiftFixtureTests/FixtureTests.swift
+++ b/Tests/SwiftFixtureTests/FixtureTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import SwiftFixture
 
 final class FixtureTests: XCTestCase {
-    struct UnregisteredType: Equatable {
+    struct UnregisteredType: Hashable {
     }
     
     enum EmptyEnum: CaseIterable, Equatable {
@@ -39,14 +39,23 @@ final class FixtureTests: XCTestCase {
         XCTAssertEqual(try fixture() as Int, 42)
         XCTAssertEqual(try fixture() as TestEnum, .three)
         XCTAssertEqual(try fixture() as Container, .init(id: 42, name: "foo"))
+        XCTAssertEqual(try fixture() as [Int], [42])
+        XCTAssertEqual(try fixture() as Set<String>, ["foo"])
+        XCTAssertEqual(try fixture() as [String: Int], ["foo": 42])
 
         // Optional
         XCTAssertEqual(try fixture() as Int?, 42)
         XCTAssertEqual(try fixture() as TestEnum?, .three)
         XCTAssertEqual(try fixture() as Container?, .init(id: 42, name: "foo"))
+        XCTAssertEqual(try fixture() as [Int]?, [42])
+        XCTAssertEqual(try fixture() as Set<String>?, ["foo"])
+        XCTAssertEqual(try fixture() as [String: Int]?, ["foo": 42])
 
         // Unregistered
         XCTAssertEqual(try fixture() as UnregisteredType?, nil)
+        XCTAssertEqual(try fixture() as [UnregisteredType], [])
+        XCTAssertEqual(try fixture() as Set<UnregisteredType>, [])
+        XCTAssertEqual(try fixture() as [String: UnregisteredType], [:])
         XCTAssertThrowsError(try fixture() as UnregisteredType) { error in
             XCTAssertTrue(error is ResolutionError)
         }


### PR DESCRIPTION
Closes #9 

`Fixture` wasn't able to produce a value for collections unless it was registered already. I thought of two ways to handle this more generically:

1. If the `Element` (or `Key` & `Value`) were already registered, we could return a collection with a single element of those types (this keeps things non-deterministic)
2. Otherwise just produce an empty collection

I was going to bake custom behaviour into `Fixture.value(for:overrides:)` but I instead opted to just make `Array`, `Set` and `Dictionary` conform to `FixtureProviding`. I was a bit on the fence about this since I didn't really want to conform system types to the public protocol (which is why we have the registration system in the first place) but the only other option was to have a separate similar internal protocol and that didn't make sense either.

Since this is a system type, and it's a protocol that we own, I don't see that adding `FixtureProviding` conformance ourselves is such a big problem. If it becomes one in the future though, we can revisit for sure.