### PR TITLE
Update documentation and tweak behaviour of Array/Set/Dictionary fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ class UserTests: XCTestCase {
 
 ## Why?
 
-Every unit test needs a fixture. Put simply, a fixture is just a piece of information that controls the environment of the test. When testing Swift code, types are your fixtures, like `user` in the above example.
+Almost every unit test will need a fixture. Put simply, a fixture is just a piece of information that controls the environment of the test. When testing Swift code, instances of your types are your fixtures, like `user` in the above example.
 
-With every unit test written, you will find yourself needing to initialize values more and more. This can start to become repetitive and as your types grow in complexity, it's likely that the initializer argument list also grows. It's not uncommon to eventually find yourself writing something like this:
+With every unit test written, you will find yourself needing to initialize values more and more. This can start to become repetitive and as your projects grow in complexity, it's likely that the initializer argument list also grows. It's not uncommon to eventually find yourself writing something like this:
 
 ```swift
 func testStateForSubscribedUser() {
@@ -107,7 +107,7 @@ func testStateForUserWithExpiredSubscription() {
 }
 ```
 
-The three _simple_ tests above end up using 90% more lines of code than they really needed and overall things end up pretty noisy. Additionally, making unrelated changes to `User` such as adding a new property require that we go back and add a new default value to each test when that property shouldn't even have been associated with this test in the first place.
+The three _simple_ tests above end up using a lot more code than they really needed and overall things end up pretty noisy. Additionally, making unrelated changes to `User` such as adding a new property require that we go back and add a new default value to each instance we initialize when that property shouldn't even have been associated with this test in the first place.
 
 With a few helper methods, you can certainly improve this a bit, but it can be hard to do so consistently when you end up having to write your own helpers. Furthermore, it is also very tempting to do things that influence your production code, such as providing default values on the main initializer.
 

--- a/Sources/SwiftFixture/Documentation.docc/SwiftFixture.md
+++ b/Sources/SwiftFixture/Documentation.docc/SwiftFixture.md
@@ -19,7 +19,6 @@ SwiftFixture provides a set of tools designed to help make it easy for you to in
 - ``FixtureProviding``
 - ``ProvideFixture()``
 
-### Misc
+### Errors
 
-- ``PreferredFormat``
 - ``ResolutionError``

--- a/Sources/SwiftFixture/FixtureProviding.swift
+++ b/Sources/SwiftFixture/FixtureProviding.swift
@@ -28,33 +28,58 @@ public protocol FixtureProviding {
     static func provideFixture(using values: ValueProvider) throws -> Self
 }
 
-// MARK: - Containers
+// MARK: - Conformances
+
+/// `fixture()` support for `Array` types
 extension Array: FixtureProviding {
+    /// Provide a fixture value for use in testing of a given `Array` type.
+    ///
+    /// - Throws: Any error thrown when resolving a fixture for `Element` apart from ``ResolutionError``.
+    /// - Returns: If a fixture can be provided for the `Element` type, an array with a single item will be returned.
+    ///   If `Element` cannot be represented as a fixture because it was not registered, an empty array will be returned instead.
     public static func provideFixture(using values: ValueProvider) throws -> Array<Element> {
-        if let value: Element = try? values.get() {
-            return [value]
-        } else {
+        do {
+            return [try values.get()]
+        } catch is ResolutionError {
             return Array()
+        } catch {
+            throw error
         }
     }
 }
 
+/// `fixture()` support for `Set` types
 extension Set: FixtureProviding {
+    /// Provide a fixture value for use in testing of a given `Set` type.
+    ///
+    /// - Throws: Any error thrown when resolving a fixture for `Element` apart from ``ResolutionError``.
+    /// - Returns: If a fixture can be provided for the `Element` type, a set with a single item will be returned.
+    ///   If `Element` cannot be represented as a fixture because it was not registered, an empty set will be returned instead.
     public static func provideFixture(using values: ValueProvider) throws -> Set<Element> {
-        if let value: Element = try? values.get() {
-            return [value]
-        } else {
+        do {
+            return [try values.get()]
+        } catch is ResolutionError {
             return Set()
+        } catch {
+            throw error
         }
     }
 }
 
+/// `fixture()` support for `Dictionary` types
 extension Dictionary: FixtureProviding {
+    /// Provide a fixture value for use in testing of a given `Dictionary` type.
+    ///
+    /// - Throws: Any error thrown when resolving a fixture for `Key` or `Value` apart from ``ResolutionError``.
+    /// - Returns: If a fixture can be provided for the `Key` and `Value` type, a dictionary with a single entry will be returned.
+    ///   If `Key` or `Value` cannot be represented as a fixture because it was not registered, an empty dictionary will be returned instead.
     public static func provideFixture(using values: ValueProvider) throws -> Dictionary<Key, Value> {
-        if let key: Key = try? values.get(), let value: Value = try? values.get() {
-            return [key: value]
-        } else {
+        do {
+            return [try values.get(): try values.get()]
+        } catch is ResolutionError {
             return Dictionary()
+        } catch {
+            throw error
         }
     }
 }


### PR DESCRIPTION
After re-reading the docs, i've made some improvements. 

Additionally, I've made the `Array`/`Set`/`Dictionary` fixture providing implementations rethrow errors not produced by SwiftFixture. It's a minor change, but feels right to me.